### PR TITLE
kernel-decompress-hook-22.04 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kernel-decompress-hook
 
-A Ubuntu kernel postinst hook which decompresses LZ4-compressed kernels.
+A Ubuntu kernel postinst hook which decompresses compressed kernels.
 
-Ubuntu started compressing their kernels with LZ4 as of the 19.10 release, and not all software yet supports that.
+Ubuntu started compressing their kernels as of the 19.10 release, and not all software yet supports that.
 
 ## Who needs this
 
@@ -12,7 +12,7 @@ This repository exists for people who are upgrading from an earlier version of U
 
 To learn more about how to use this script, visit:
 
-https://kb.sitehost.nz/servers/upgrading/upgrading-ubuntu-18-04-to-20-04
+https://kb.sitehost.nz/servers/upgrading/upgrading-ubuntu-18-04-to-20-04 
 
 ## Support
 

--- a/kernel-decompress-hook
+++ b/kernel-decompress-hook
@@ -32,13 +32,6 @@ trap "rm -f ${TEMP_FILE}" 0
 # If the given kernel file is still a bzimage see if its needs decompression
 if echo "$(file -b "${KERNEL_PATH}")" | grep -q "^Linux kernel x86 boot executable bzImage"; then
 
-        # Kernel is probably lz4 if there are lz4 headers in it
-        LZ4_HEADER="$(printf '\002!L\030')"
-        if ! grep -aqo "${LZ4_HEADER}" ${KERNEL_PATH}; then
-                echo "No lz4 compression headers found, skipping..."
-                exit 0
-        fi
-
         echo "Decompressing '${KERNEL_PATH}'..."
         # Extract the kernel and replace existing if successful
         if extract-vmlinux ${KERNEL_PATH} > ${TEMP_FILE}; then


### PR DESCRIPTION
`extract-vmlinux` can handle format detection to correctly unpack `linux-image-5.15*` kernels from 22.04 
